### PR TITLE
V0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,31 +121,24 @@ $ main.py -f files/drivers.json -o output/stats.csv --ignore 2
 
 1. Do I have to put my iRacing credentials?
 
-```
-Yes. iRacing doesn't have any API so the only valid method is using your account. It's fair you don't trust me but you can check my code.
-```
+>Yes. iRacing doesn't have any API so the only valid method is using your account. It's fair you don't trust me but you can check my code.
 
 2. Have you used it?
-```
-It's running on my Raspberry Pi every morning. 
-```
+
+>It's running on my Raspberry Pi every morning. 
 
 3. Where can I find the customerid?
 
-```
-If visit your mate's profile, his id is at the end of the url after ?custid=.
-```
+>If visit your mate's profile, his id is at the end of the url after ?custid=.
 
 4. I would love having the csv file on my Dropbox/GDrive folder or Discord channel automatically.
 
-``` 
-I won't add sync to this script but I might write a small script for Dropbox/Discord.
-```
+> I won't add sync to this script but I might write a small script for Dropbox/Discord.
 
 5. Can I modify/copy it?
-```
-Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature you can create a PR.
-```
+
+> Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature you can create a PR.
+
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ This python script makes your life easier because you will get an updated SR/ira
 You won't need to waste time visiting all profiles and updating a document. SR and iRating info is exported to a CSV
 file. 
 
+This script has been tested in Python 3.5, 3.6 and 3.7.
 
-## Usage
-
-### Installation
+## Installation
 
 I recommend you to create a virtual environment and install all dependencies there. As soon as it's ready and activated,
 you can install all dependencies:
@@ -26,12 +25,12 @@ If you want to run tests, you have to install requirements-test.txt because they
 pip install -r requirements-text.txt
 ```
 
-And then:
+And then type:
 ```bash
  nosetests -v
 ```
 
-## Application
+## Configuration
 
 ### settings.py
 You have to open settings.py and edit these two lines adding your iRacing email/password:
@@ -50,54 +49,113 @@ you have to follow the following structure. (Note that names and ids are fiction
   [
     {"name": "Archaon the Everchosen", "id":4012 },
     {"name": "Garrett Branko", "id":1540}
-   /* More memebers */
   ]
 }
 ```
 The name can be different to the real one used on iR (useful if your mates have +4 names and you want a short version) but 
 the id must be right or you will get stats from other guy.
 
-### Run
-Main.py is the only executable file. The behaviour can be changed using some commandline params that you can see below:
+## Command-line arguments
+Main.py is the only executable file and the behaviour can be changed using some commandline params:
 
-|Arg|Optional|Description|
-|-------|-------|------|
-|-f --file|No|Json file with drivers' info - can be a path|
-|-o --output|Yes|Output csv file - can be a path|
+### -h/--help
+
+```
+$ main.py -h 
+$ main.py --help
+```
+This will show you a list of possible command-line flags.
+
+### -f/ --file
+```
+$ main.py -f drivers.json 
+$ main.py --file files/drivers.json
+```
+
+Indicates the input file tha the script will use. You can have this file in the same level that main.py or different folder.
+It's a required flag so if you miss it you will get an error. In order to keep this tutorial simple, this flag is missing in the next explanations. 
+
+### -o/ --output
+```
+$ main.py -o stats.csv 
+$ main.py --file /output/stats.csv
+```
+
+By default stats are exported to a csv file named DriversStats.csv and you find it in the project root. With this flag,
+you can change the name of the file and exported to a different folder.
+
+
+### --ignore
+```
+$ main.py --ignore 2
+$ $ main.py --ignore 3,4
+```
+
+By default it exports oval,road and both dirt licences but this flag lets you skip those you don't care. Values must be
+between 1-4 and below you can see licence-number relation:
+
+* 1: Oval
+* 2: Road
+* 3: Dirt-Oval
+* 4: Dirt-Road
 
 __Examples:__
 
-drivers.json as input file and default output filename.
-> main.py -f drivers.json
+Drivers.json file as input and both oval licences aren't exported. Output file will be DriversStats.csv.
+```
+$ main.py -f drivers.json --ignore 1,3
+```
 
-drivers.json(inside files folder) as input file and info will be exported to stats.csv.
-> main.py -f files/drivers.json -o stats.csv
+Drivers.json file (store in a folder) and info will be exported to a file named stats.csv.
+```
+$ main.py -f files/drivers.json -o stats.csv
+```
 
-Error because no input file was given.
-> main.py  -o stats.csv
+Drivers.json (inside a folder) as input file, info will be exported to a file named stats.csv(inside a folder) and skip road info.
+```
+$ main.py -f files/drivers.json -o output/stats.csv --ignore 2
+```
+
 
 ## FAQ
 
 1. Do I have to put my iRacing credentials?
 
-> Yes. iRacing doesn't have any API so the only valid method is using your account. It's fair you don't trust me but you can check 
-my code
+```
+Yes. iRacing doesn't have any API so the only valid method is using your account. It's fair you don't trust me but you can check my code.
+```
 
 2. Have you used it?
+```
+It's running on my Raspberry Pi every morning. 
+```
 
-> It's running on my Raspberry Pi every morning. 
+3. Where can I find the customerid?
 
-3. Where can I find the customerid from my mate?
-
-> If visit his profile, his id is at the end of the url after ?custid= .
+```
+If visit your mate's profile, his id is at the end of the url after ?custid=.
+```
 
 4. I would love having the csv file on my Dropbox/GDrive folder or Discord channel automatically.
-   
-> I won't add sync to this script but I might write a small one so the file would be on Discord or/and Dropbox.
+
+``` 
+I won't add sync to this script but I might write a small script for Dropbox/Discord.
+```
 
 5. Can I modify/copy it?
-> Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature you can create a
-PR.
+```
+Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature you can create a PR.
+```
+
+## Changelog
+
+__V0.0.2 (17/02/2019)__
+
+* Added ignore licence flag and it won't appear in the csv file. 
+
+__V0.0.1 (06/02/2019)__
+
+* Initial release.
 
 
 *Thanks to Juri, his laziness made this script possible ;).*

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 # IR-Profile-Tracker
 
 This python script makes your life easier because you will get an updated SR/irating file of your teammates.
-You won't need to waste time visiting all profiles and updating a document. At this moment SR and iRating info is exported 
-to a CSV file but other formats should be available #soon.
+You won't need to waste time visiting all profiles and updating a document. SR and iRating info is exported to a CSV
+file. 
+
 
 ## Usage
 
@@ -84,21 +85,18 @@ my code
 
 2. Have you used it?
 
-> I've tested it and a modified version of this script is running on my Raspberry Pi every morning. 
+> It's running on my Raspberry Pi every morning. 
 
 3. Where can I find the customerid from my mate?
 
 > If visit his profile, his id is at the end of the url after ?custid= .
 
-4. I only care about <insert road/oval/dirt licence here>
-> At this moment all licences are exported but in the future you might be able to filter those you don't care. 
-
-5. I would love having the csv file on my Dropbox/GDrive folder or Discord channel automatically.
+4. I would love having the csv file on my Dropbox/GDrive folder or Discord channel automatically.
    
-> Sync feature is on my TODO list and #soon. Discord and Dropbox could be the first services supported.
+> I won't add sync to this script but I might write a small one so the file would be on Discord or/and Dropbox.
 
-6. Can I modify/copy it?
-> Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature, you can create a
+5. Can I modify/copy it?
+> Of course!. It's under MIT Licence so feel free to do whatever you want. If you make an awesome feature you can create a
 PR.
 
 

--- a/ir_profile_tracker/irClient.py
+++ b/ir_profile_tracker/irClient.py
@@ -46,7 +46,7 @@ class IrClient(object):
 
     def get_irating(self, memberid, racetype=RaceType.Oval):
         """
-        Gets irtaing from a member
+        Gets irating from a member
         :param memberid: iracing customer id
         :param racetype: Licence
         :return: irating value; None if there was an error

--- a/ir_profile_tracker/models.py
+++ b/ir_profile_tracker/models.py
@@ -118,6 +118,18 @@ class Member(object):
         else:
             raise ValueError("{0} is not a valid irating".format(irating))
 
+    def irating_as_dict(self):
+        """
+        :return: A dict with the following structure: {Racetype: irating}
+        """
+        return self._irating.copy()
+
+    def sr_as_dict(self):
+        """
+        :return: A dict with the following structure: {Racetype: SR object}
+        """
+        return self._sr.copy()
+
     @property
     def road_irating(self):
         return self._irating[RaceType.Road]

--- a/ir_profile_tracker/models.py
+++ b/ir_profile_tracker/models.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from collections import OrderedDict
 
 
 class Licence(Enum):
@@ -91,8 +92,8 @@ class Member(object):
         self.custid = custid
         self.name = name
 
-        self._sr = {key: SR() for key in RaceType}
-        self._irating = {key: 0 for key in RaceType}
+        self._sr = OrderedDict((key, SR()) for key in RaceType)
+        self._irating = OrderedDict((key, 0) for key in RaceType)
 
     def __str__(self):
         return "{0} - {1}".format(self.name, self.custid)

--- a/ir_profile_tracker/utils.py
+++ b/ir_profile_tracker/utils.py
@@ -1,0 +1,64 @@
+import csv
+import json
+import time
+from datetime import datetime
+from ir_profile_tracker.models import RaceType, Member
+
+
+def update_drivers_stats(drivers, irClient):
+    """
+    Updates drivers'info(irating and SR).
+    :param drivers: Array that contains all memebers. See models.Member.
+    :param irClient: irClient instance
+    """
+    for driver in drivers:
+        print("Getting iR/SR from driver {0}".format(driver))
+        for rt in RaceType:
+            irating = irClient.get_irating(driver.custid, rt.value)
+            time.sleep(.5)
+            sr = irClient.get_SR(driver.custid, rt.value)
+
+            driver.update_irating(rt, irating)
+            driver.update_sr(rt, sr)
+
+
+def drivers_to_csv(drivers, filename=None):
+    """
+    Exports drivers stats to a csv file
+    :param drivers: Array with all members
+    :param filename: outputfile extension included
+    """
+    output_file = filename if filename else 'driversStats.csv'
+    with open(output_file, 'w') as file:
+        csvfile = csv.writer(file, delimiter=',')
+
+        csvfile.writerow(['Name', 'Id', 'ir-Road', 'ir-Oval', 'ir-DRoad', 'ir-DOval', 'sr-Road', 'sr-Oval',
+                         'sr-DRoad', 'sr-DOval', 'Profile'])
+
+        for driver in drivers:
+            csvfile.writerow([driver.name, driver.custid, driver.road_irating, driver.oval_irating,
+                              driver.dRoad_irating, driver.dOval_irating, driver.road_sr, driver.oval_sr,
+                              driver.dRoad_sr, driver.dOval_sr, driver.profile_url])
+
+        ts = datetime.utcnow().strftime("%d-%b-%Y %H:%M:%S UTC")
+        csvfile.writerow(['' for item in range(0, 9)])
+        csvfile.writerow(["Created: " + ts])
+        print("File {0} created".format(filename))
+
+
+def parse_drivers(filepath):
+    """
+    Converts driver info from json to Member; see models.Member
+    :param filepath: Path where json file is
+    :return: Array with all members from json file; Empy array if file is empty
+    """
+    with open(filepath) as data:
+        drivers = json.load(data)
+
+        members = []
+        for item in drivers['drivers']:
+            member = Member(custid=item['id'], name=item['name'])
+            members.append(member)
+            print("Member {0} parsed".format(member))
+
+    return members

--- a/ir_profile_tracker/utils.py
+++ b/ir_profile_tracker/utils.py
@@ -5,15 +5,17 @@ from datetime import datetime
 from ir_profile_tracker.models import RaceType, Member
 
 
-def update_drivers_stats(drivers, irClient):
+def update_drivers_stats(drivers, irClient, ignore_licences=[]):
     """
     Updates drivers'info(irating and SR).
     :param drivers: Array that contains all memebers. See models.Member.
     :param irClient: irClient instance
+    :param ignore_licences
     """
+    licences = [rt for rt in RaceType if rt.value not in ignore_licences]
     for driver in drivers:
         print("Getting iR/SR from driver {0}".format(driver))
-        for rt in RaceType:
+        for rt in licences:
             irating = irClient.get_irating(driver.custid, rt.value)
             time.sleep(.5)
             sr = irClient.get_SR(driver.custid, rt.value)
@@ -22,28 +24,33 @@ def update_drivers_stats(drivers, irClient):
             driver.update_sr(rt, sr)
 
 
-def drivers_to_csv(drivers, filename=None):
+def drivers_to_csv(drivers, filename=None, ignore_licences=[]):
     """
     Exports drivers stats to a csv file
     :param drivers: Array with all members
-    :param filename: outputfile extension included
+    :param filename: output file extension included
+    :param ignore_licences
     """
     output_file = filename if filename else 'driversStats.csv'
+    ir_headers = ["ir_{0}".format(rt.name) for rt in RaceType if rt.value not in ignore_licences]
+    sr_headers = ["sr_{0}".format(rt.name) for rt in RaceType if rt.value not in ignore_licences]
+
     with open(output_file, 'w') as file:
         csvfile = csv.writer(file, delimiter=',')
-
-        csvfile.writerow(['Name', 'Id', 'ir-Road', 'ir-Oval', 'ir-DRoad', 'ir-DOval', 'sr-Road', 'sr-Oval',
-                         'sr-DRoad', 'sr-DOval', 'Profile'])
+        csvfile.writerow(['Name', 'Id'] + ir_headers + sr_headers + ['Profile'])
 
         for driver in drivers:
-            csvfile.writerow([driver.name, driver.custid, driver.road_irating, driver.oval_irating,
-                              driver.dRoad_irating, driver.dOval_irating, driver.road_sr, driver.oval_sr,
-                              driver.dRoad_sr, driver.dOval_sr, driver.profile_url])
+            ir_dict = driver.irating_as_dict()
+            sr_dict = driver.sr_as_dict()
+            ir_info = [ir_dict[key] for key in ir_dict.keys() if key.value not in ignore_licences]
+            sr_info = [str(sr_dict[key]) for key in sr_dict.keys() if key.value not in ignore_licences]
+
+            csvfile.writerow([driver.name, driver.custid] + ir_info + sr_info + [driver.profile_url])
 
         ts = datetime.utcnow().strftime("%d-%b-%Y %H:%M:%S UTC")
-        csvfile.writerow(['' for item in range(0, 9)])
+        csvfile.writerow([])
         csvfile.writerow(["Created: " + ts])
-        print("File {0} created".format(filename))
+        print("File {0} created".format(output_file))
 
 
 def parse_drivers(filepath):

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def parse_args(args):
 def main(args):
     parser = parse_args(args)
     file = parser.file
-    ignore_list = parser.ignore
+    ignore_list = parser.ignore or []
 
     if os.path.exists(file):
         drivers = parse_drivers(file)

--- a/main.py
+++ b/main.py
@@ -1,71 +1,9 @@
 import argparse
 import sys
 import os
-import csv
-import json
-import time
-from datetime import datetime
 import settings
-from ir_profile_tracker.models import Member, RaceType
 from ir_profile_tracker.irClient import IrClient
-
-
-def update_drivers_stats(drivers, irClient):
-    """
-    Updates drivers'info(irating and SR).
-    :param drivers: Array that contains all memebers. See models.Member.
-    :param irClient: irClient instance
-    """
-    for driver in drivers:
-        print("Getting iR/SR from driver {0}".format(driver))
-        for rt in RaceType:
-            irating = irClient.get_irating(driver.custid, rt.value)
-            time.sleep(.5)
-            sr = irClient.get_SR(driver.custid, rt.value)
-
-            driver.update_irating(rt, irating)
-            driver.update_sr(rt, sr)
-
-
-def parse_drivers(filepath):
-    """
-    Converts driver info from json to Member; see models.Member
-    :param filepath: Path where json file is
-    :return: Array with all members from json file; Empy array if file is empty
-    """
-    with open(filepath) as data:
-        drivers = json.load(data)
-
-        members = []
-        for item in drivers['drivers']:
-            member = Member(custid=item['id'], name=item['name'])
-            members.append(member)
-            print("Member {0} parsed".format(member))
-
-    return members
-
-
-def drivers_to_csv(drivers, filename="driversStats.csv"):
-    """
-    Exports drivers stats to a csv file
-    :param drivers: Array with all members
-    :param filename: outputfile extension included
-    """
-    with open(filename, 'w') as file:
-        csvfile = csv.writer(file, delimiter=',')
-
-        csvfile.writerow(['Name', 'Id', 'ir-Road', 'ir-Oval', 'ir-DRoad', 'ir-DOval', 'sr-Road', 'sr-Oval',
-                         'sr-DRoad', 'sr-DOval', 'Profile'])
-
-        for driver in drivers:
-            csvfile.writerow([driver.name, driver.custid, driver.road_irating, driver.oval_irating,
-                              driver.dRoad_irating, driver.dOval_irating, driver.road_sr, driver.oval_sr,
-                              driver.dRoad_sr, driver.dOval_sr, driver.profile_url])
-
-        ts = datetime.utcnow().strftime("%d-%b-%Y %H:%M:%S UTC")
-        csvfile.writerow(['' for item in range(0, 9)])
-        csvfile.writerow(["Created: " + ts])
-        print("File {0} created".format(filename))
+from ir_profile_tracker.utils import update_drivers_stats, drivers_to_csv, parse_drivers
 
 
 def parse_args(args):
@@ -85,11 +23,7 @@ def main(args):
         client = IrClient()
         if client.login(settings.IRACING_EMAIL, settings.IRACING_PASSWORD):
             update_drivers_stats(drivers, client)
-
-            if parser.output:
-                drivers_to_csv(drivers, parser.output)
-            else:
-                drivers_to_csv(drivers)
+            drivers_to_csv(drivers, parser.output)
     else:
         raise FileNotFoundError("File {0} not found".format(parser.file))
 

--- a/main.py
+++ b/main.py
@@ -3,13 +3,28 @@ import sys
 import os
 import settings
 from ir_profile_tracker.irClient import IrClient
+from ir_profile_tracker.models import RaceType
 from ir_profile_tracker.utils import update_drivers_stats, drivers_to_csv, parse_drivers
+
+
+class IgnoreLicenceAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        choices = [item.value for item in RaceType]
+        ignore_list = []
+        for value in values:
+            if value not in choices:
+                raise argparse.ArgumentError(self, "Value {0} is not a valid licence".format(value))
+            ignore_list.append(value)
+
+        setattr(namespace, self.dest, ignore_list)
 
 
 def parse_args(args):
     parser = argparse.ArgumentParser(description='IR_Profile_Tracker')
     parser.add_argument('-f', '--file', help="Filename that contains driver's info'.", required=True)
     parser.add_argument('-o', '--output', help="Name of the output file(extension included).")
+    parser.add_argument('--ignore', action=IgnoreLicenceAction, nargs='*', type=int,
+                        help="Licences that will not be exported (1-O, 2-R, 3-Dov, 4-Dr).")
 
     return parser.parse_args(args)
 
@@ -17,13 +32,15 @@ def parse_args(args):
 def main(args):
     parser = parse_args(args)
     file = parser.file
+    ignore_list = parser.ignore
+
     if os.path.exists(file):
         drivers = parse_drivers(file)
 
         client = IrClient()
         if client.login(settings.IRACING_EMAIL, settings.IRACING_PASSWORD):
-            update_drivers_stats(drivers, client)
-            drivers_to_csv(drivers, parser.output)
+            update_drivers_stats(drivers, client, ignore_list)
+            drivers_to_csv(drivers, parser.output, ignore_list)
     else:
         raise FileNotFoundError("File {0} not found".format(parser.file))
 

--- a/tests/test_irClient.py
+++ b/tests/test_irClient.py
@@ -41,7 +41,6 @@ class TestiRClient(TestCase):
             with assert_raises(Exception):
                 self.client.login('joe@example.com', 'password')
 
-
     def test_get_SR_chart(self):
         with patch.object(self.client, 'session') as session:
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,80 +1,11 @@
 from unittest import TestCase
 from unittest import mock
-import json
-from datetime import datetime
-from nose.tools import assert_equal, assert_raises, assert_list_equal, assert_true
+from nose.tools import assert_equal, assert_raises, assert_true
 from ir_profile_tracker.models import Member
 import main
 
 
-class TestMain(TestCase):
-
-    def setUp(self):
-        self.member = Member(name="John Doe", custid=2020)
-
-    def get_write_calls_arg(self, mock_calls, index):
-        """
-        Bypass to get all args from every write call when csv file is being writed. I tried all assert methods from mock
-        module but I did something wrong so, this method allows me to check if file constains the right info.
-
-        :param mock_calls: mock.mock_calls array
-        :param index: Index in the mock_calls array
-        :return: Array with all args as str.
-        """
-        calls = [item[1][0] for item in mock_calls if item[0] == "().__enter__().write"]
-        call = calls[index]
-        args = call.replace('\n', '').replace('\r', '')
-        return args.split(',')
-
-    @mock.patch('main.os.path.exists')
-    def test_main_file_not_exists_raise_FileException(self, mock_os):
-        mock_os.return_value = False
-        with assert_raises(FileNotFoundError):
-            main.main(["-f", "file.json"])
-
-    @mock.patch('main.os.path.exists')
-    @mock.patch('main.parse_drivers')
-    @mock.patch('main.IrClient')
-    @mock.patch('main.update_drivers_stats')
-    @mock.patch('main.drivers_to_csv')
-    def test_main(self, mock_csv, mock_up_drivers, mock_client, mock_p_drivers, mock_os):
-        filename = 'file.json'
-        member = Member(custid=2020, name="John")
-        mock_os.return_value = True
-        mock_p_drivers.return_value = [member]
-
-        client_instance = mock.MagicMock()
-        mock_client.return_value = client_instance
-        client_instance.login.return_value = True
-
-        main.main(["-f", filename])
-
-        mock_p_drivers.assert_called_once_with(filename)
-        assert_true(client_instance.login.called)
-        assert_equal(mock_up_drivers.call_args[0][0][0], member)
-        assert_true(mock_up_drivers.called)
-        mock_csv.assert_called_once_with([member])
-
-    @mock.patch('main.os.path.exists')
-    @mock.patch('main.parse_drivers')
-    @mock.patch('main.IrClient')
-    @mock.patch('main.update_drivers_stats')
-    @mock.patch('main.drivers_to_csv')
-    def test_main_custom_output_file(self, mock_csv, mock_up_drivers, mock_client, mock_p_drivers, mock_os):
-        filename = 'file.json'
-        output = "stats.csv"
-
-        member = Member(custid=2020, name="John")
-        mock_os.return_value = True
-        mock_p_drivers.return_value = [member]
-
-        client_instance = mock.MagicMock()
-        mock_client.return_value = client_instance
-        client_instance.login.return_value = True
-
-        main.main(["-f", filename, '-o', output])
-
-        mock_csv.assert_called_once_with([member], output)
+class TestArgumentParser(TestCase):
 
     def test_parse_file_arg(self):
         parse = main.parse_args(["-f", "file.json"])
@@ -88,72 +19,56 @@ class TestMain(TestCase):
         with assert_raises(SystemExit):
             main.parse_args([])
 
-    @mock.patch("builtins.open")
-    def test_drivers_to_csv_open_file(self, mock_open):
-        main.drivers_to_csv([self.member])
-        mock_open.assert_called_once_with("driversStats.csv", "w")
 
-    @mock.patch("builtins.open")
-    def test_drivers_to_csv_drivers_info(self, mock_open):
-        main.drivers_to_csv([self.member])
-        mock_open.assert_called_once_with("driversStats.csv", "w")
-        assert_equal(mock_open().__enter__().write.call_count, 4)
+class TestMain(TestCase):
 
-        drivers_call_args = self.get_write_calls_arg(mock_open.mock_calls, 1)
-        driver_expected_args = [self.member.name, self.member.custid, self.member.road_irating,
-                                self.member.oval_irating, self.member.dRoad_irating, self.member.dOval_irating,
-                                self.member.road_sr, self.member.oval_sr, self.member.dRoad_sr,
-                                self.member.dOval_sr, self.member.profile_url]
+    def setUp(self):
+        self.member = Member(name="John Doe", custid=2020)
+        self.client_instance = mock.MagicMock()
+        self.client_instance.login.return_value = True
 
-        assert_list_equal(drivers_call_args, [str(item) for item in driver_expected_args])
+    @mock.patch('main.os.path.exists')
+    def test_main_file_not_exists_raise_FileException(self, mock_os):
+        mock_os.return_value = False
+        with assert_raises(FileNotFoundError):
+            main.main(["-f", "file.json"])
 
-    @mock.patch("builtins.open")
-    @mock.patch("main.datetime")
-    def test_drivers_to_csv_created_date(self, mock_dt, mock_open):
-        today = datetime(2019, 2, 4, 1, 0, 0, 0)
-        mock_dt.utcnow.return_value = today
+    @mock.patch('main.os.path.exists')
+    @mock.patch('main.parse_drivers')
+    @mock.patch('main.IrClient')
+    @mock.patch('main.update_drivers_stats')
+    @mock.patch('main.drivers_to_csv')
+    def test_main(self, mock_csv, mock_update_drivers, mock_client, mock_parse_drivers, mock_os):
+        filename = 'file.json'
+        mock_os.return_value = True
+        mock_parse_drivers.return_value = [self.member]
+        mock_client.return_value = self.client_instance
 
-        main.drivers_to_csv([self.member])
-        date_call_args = self.get_write_calls_arg(mock_open.mock_calls, 3)
+        main.main(["-f", filename])
 
-        assert_equal(date_call_args[0], "Created: " + today.strftime("%d-%b-%Y %H:%M:%S UTC"))
-        assert_equal(mock_open().__enter__().write.call_count, 4)
+        assert_true(mock_update_drivers.called)
+        assert_true(self.client_instance.login.called)
 
-    @mock.patch("builtins.open")
-    def test_drivers_to_csv_file_headers(self, mock_open):
-        main.drivers_to_csv([self.member])
+        mock_parse_drivers.assert_called_once_with(filename)
+        mock_update_drivers.assert_called_once_with([self.member], self.client_instance)
+        mock_csv.assert_called_once_with([self.member], None)
 
-        headers_call_args = self.get_write_calls_arg(mock_open.mock_calls, 0)
-        headers_expected = ['Name', 'Id', 'ir-Road', 'ir-Oval', 'ir-DRoad', 'ir-DOval', 'sr-Road', 'sr-Oval',
-                            'sr-DRoad', 'sr-DOval', 'Profile']
+    @mock.patch('main.os.path.exists')
+    @mock.patch('main.parse_drivers')
+    @mock.patch('main.IrClient')
+    @mock.patch('main.update_drivers_stats')
+    @mock.patch('main.drivers_to_csv')
+    def test_main_custom_output_file(self, mock_csv, mock_update_drivers, mock_client, mock_parse_drivers, mock_os):
+        filename = 'file.json'
+        output = "stats.csv"
 
-        assert_list_equal(headers_call_args, headers_expected)
-        assert_equal(mock_open().__enter__().write.call_count, 4)
+        mock_client.return_value = self.client_instance
+        self.client_instance.login.return_value = True
+        mock_os.return_value = True
+        mock_parse_drivers.return_value = [self.member]
 
-    @mock.patch("builtins.open", mock.mock_open(read_data=json.dumps({"drivers": [{"name": "John Doe", "id": 2020}]})))
-    def test_parse_drivers(self):
-            drivers = main.parse_drivers("path")
+        main.main(["-f", filename, '-o', output])
 
-            assert_equal(len(drivers), 1)
-            assert_equal("John Doe", drivers[0].name)
-            assert_equal(2020, drivers[0].custid)
-
-    @mock.patch('main.time.sleep', return_value=None)
-    def test_update_drivers(self, mock_time):
-        client = mock.Mock()
-        ir_list = [1000, 1500, 3000, 2500]
-        sr_list = [2342, 4365, 5499, 2128]
-
-        client.get_irating.side_effect = ir_list
-        client.get_SR.side_effect = sr_list
-
-        main.update_drivers_stats([self.member], client)
-
-        assert_equal(client.get_irating.call_count, 4)
-        assert_equal(client.get_SR.call_count, 4)
-
-        assert_list_equal(sr_list, [self.member.oval_sr.licence_as_number, self.member.road_sr.licence_as_number,
-                                    self.member.dOval_sr.licence_as_number, self.member.dRoad_sr.licence_as_number])
-
-        assert_list_equal(ir_list, [self.member.oval_irating, self.member.road_irating,
-                                    self.member.dOval_irating, self.member.dRoad_irating])
+        assert_true(mock_update_drivers.called)
+        mock_csv.assert_called_once_with([self.member], output)
+        mock_update_drivers.assert_called_once_with([self.member], self.client_instance)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,8 +88,8 @@ class TestMain(TestCase):
         assert_true(self.client_instance.login.called)
 
         mock_parse_drivers.assert_called_once_with(filename)
-        mock_update_drivers.assert_called_once_with([self.member], self.client_instance, None)
-        mock_csv.assert_called_once_with([self.member], None, None)
+        mock_update_drivers.assert_called_once_with([self.member], self.client_instance, [])
+        mock_csv.assert_called_once_with([self.member], None, [])
 
     @mock.patch('main.os.path.exists')
     @mock.patch('main.parse_drivers')
@@ -108,5 +108,5 @@ class TestMain(TestCase):
         main.main(["-f", filename, '-o', output])
 
         assert_true(mock_update_drivers.called)
-        mock_csv.assert_called_once_with([self.member], output, None)
-        mock_update_drivers.assert_called_once_with([self.member], self.client_instance, None)
+        mock_csv.assert_called_once_with([self.member], output, [])
+        mock_update_drivers.assert_called_once_with([self.member], self.client_instance, [])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises, assert_list_equal
 from ir_profile_tracker.models import Member, SR, RaceType
 
 
@@ -92,3 +92,21 @@ class TestMember(TestCase):
         self.member.update_sr(RaceType.Dirt_Oval, value)
         assert_equal(self.member.dOval_sr.number, 3.50)
         assert_equal(self.member.dOval_sr.licence_class, 'PRO_WC')
+
+    def test_irating_as_dict(self):
+        ir_expected = [1000, 2500, 3850, 6200]
+
+        for item in range(0, 4):
+            self.member.update_irating(RaceType(item+1), ir_expected[item])
+
+        values = [item for item in self.member.irating_as_dict().values()]
+        assert_list_equal(ir_expected, values)
+
+    def test_sr_as_dict(self):
+        sr_expected = [2342, 4365, 5499, 2128]
+
+        for item in range(0, 4):
+            self.member.update_sr(RaceType(item+1), sr_expected[item])
+
+        values = [item.licence_as_number for item in self.member.sr_as_dict().values()]
+        assert_list_equal(sr_expected, values)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,106 @@
+from unittest import TestCase
+from unittest import mock
+import json
+from datetime import datetime
+from nose.tools import assert_equal, assert_raises, assert_list_equal, assert_true
+from ir_profile_tracker import utils
+from ir_profile_tracker.models import Member
+
+
+class TestExportCSV(TestCase):
+
+    def setUp(self):
+        self.member = Member(name="John Doe", custid=2020)
+
+    def get_write_calls_arg(self, mock_calls, index):
+        """
+        Bypass to get all args from every write call when csv file is being writed. I tried all assert methods from mock
+        module but I did something wrong so, this method allows me to check if file constains the right info.
+
+        :param mock_calls: mock.mock_calls array
+        :param index: Index in the mock_calls array
+        :return: Array with all args as str.
+        """
+        calls = [item[1][0] for item in mock_calls if item[0] == "().__enter__().write"]
+        call = calls[index]
+        args = call.replace('\n', '').replace('\r', '')
+        return args.split(',')
+
+    @mock.patch("builtins.open")
+    def test_drivers_to_csv_member_info(self, mock_open):
+        driver_expected_args = [self.member.name, self.member.custid, self.member.road_irating,
+                                self.member.oval_irating, self.member.dRoad_irating, self.member.dOval_irating,
+                                self.member.road_sr, self.member.oval_sr, self.member.dRoad_sr,
+                                self.member.dOval_sr, self.member.profile_url]
+
+        utils.drivers_to_csv([self.member])
+
+        drivers_call_args = self.get_write_calls_arg(mock_open.mock_calls, 1)
+
+        mock_open.assert_called_once_with("driversStats.csv", "w")
+        assert_list_equal(drivers_call_args, [str(item) for item in driver_expected_args])
+
+    @mock.patch("builtins.open")
+    @mock.patch("ir_profile_tracker.utils.datetime")
+    def test_drivers_to_csv_created_date(self, mock_dt, mock_open):
+        today = datetime(2019, 2, 4, 1, 0, 0, 0)
+        mock_dt.utcnow.return_value = today
+
+        utils.drivers_to_csv([self.member])
+        date_call_args = self.get_write_calls_arg(mock_open.mock_calls, 3)
+        assert_equal(date_call_args[0], "Created: " + today.strftime("%d-%b-%Y %H:%M:%S UTC"))
+
+    @mock.patch("builtins.open")
+    def test_drivers_to_csv_file_headers(self, mock_open):
+        utils.drivers_to_csv([self.member])
+
+        headers_call_args = self.get_write_calls_arg(mock_open.mock_calls, 0)
+        headers_expected = ['Name', 'Id', 'ir-Road', 'ir-Oval', 'ir-DRoad', 'ir-DOval', 'sr-Road', 'sr-Oval',
+                            'sr-DRoad', 'sr-DOval', 'Profile']
+
+        assert_list_equal(headers_call_args, headers_expected)
+
+    @mock.patch("builtins.open")
+    def test_drivers_to_csv_custom_file(self, mock_os):
+        filename = "myfile.csv"
+        utils.drivers_to_csv([self.member], filename)
+        mock_os.assert_called_once_with(filename, "w")
+
+    @mock.patch("builtins.open")
+    def test_drivers_to_csv_custom_file_error(self, mock_os):
+        filename = "output/myfile.csv"
+        mock_os.side_effect = IOError()
+
+        with assert_raises(IOError):
+            utils.drivers_to_csv([self.member], filename)
+
+
+class TestUtils(TestCase):
+
+    @mock.patch('ir_profile_tracker.utils.time.sleep', return_value=None)
+    def test_update_drivers(self, mock_time):
+        member = Member(name="John Doe", custid=2020)
+        client = mock.Mock()
+        ir_list = [1000, 1500, 3000, 2500]
+        sr_list = [2342, 4365, 5499, 2128]
+
+        client.get_irating.side_effect = ir_list
+        client.get_SR.side_effect = sr_list
+        utils.update_drivers_stats([member], client)
+
+        assert_equal(client.get_irating.call_count, 4)
+        assert_equal(client.get_SR.call_count, 4)
+
+        assert_list_equal(sr_list, [member.oval_sr.licence_as_number, member.road_sr.licence_as_number,
+                                    member.dOval_sr.licence_as_number, member.dRoad_sr.licence_as_number])
+
+        assert_list_equal(ir_list, [member.oval_irating, member.road_irating,
+                                    member.dOval_irating, member.dRoad_irating])
+
+    @mock.patch("builtins.open", mock.mock_open(read_data=json.dumps({"drivers": [{"name": "John Doe", "id": 2020}]})))
+    def test_parse_drivers(self):
+            drivers = utils.parse_drivers("path")
+
+            assert_equal(len(drivers), 1)
+            assert_equal("John Doe", drivers[0].name)
+            assert_equal(2020, drivers[0].custid)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ class TestExportCSV(TestCase):
             self.member.update_sr(rt, sr[rt.value-1])
             self.member.update_irating(rt, ir[rt.value-1])
 
-
     def get_write_calls_arg(self, mock_calls, index):
         """
         Bypass to get all args from every write call when csv file is being writed. I tried all assert methods from mock

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ class TestExportCSV(TestCase):
         mock_dt.utcnow.return_value = today
 
         utils.drivers_to_csv([self.member])
-        date_call_args = self.get_write_calls_arg(mock_open.mock_calls, 2)
+        date_call_args = self.get_write_calls_arg(mock_open.mock_calls, 3)
         assert_equal(date_call_args[0], "Created: " + today.strftime("%d-%b-%Y %H:%M:%S UTC"))
 
     @mock.patch("builtins.open")


### PR DESCRIPTION
Added ignore licence flag. It allows you to skip those licences that you don't care, improving the speed of the script.

Dicts from Member class has been changed to OrderedDict because implementation differs from 3.5 to  +3.6.